### PR TITLE
Replaces rule for height to min-height

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -6,3 +6,8 @@
 #contact img {
   padding-top: 120px;
 }
+
+body .navbar {
+  height: inherit;
+  min-height: 30px;
+}


### PR DESCRIPTION
This should fix the "transparency" issue when the menu is expanded in the mobile view.

The transparency effect happens because the navbar height remains at 30px and doesn't expand with the mobile dropdown.